### PR TITLE
fix shaders

### DIFF
--- a/shaders/common/fog.fsh
+++ b/shaders/common/fog.fsh
@@ -7,9 +7,9 @@ uniform float far;
 
 #if defined(DYNAMIC_FOG) && !defined(THE_NETHER) && !defined(THE_END)
     uniform ivec2 eyeBrightnessSmooth;
-    float eyeBrightnessSmooth_f() {return eyeBrightnessSmooth.y/240.;}
+    float eyeBrightnessSmooth_f() {return eyeBrightnessSmooth.y/240.0;}
 #else
-    float eyeBrightnessSmooth_f() {return 1.;}
+    float eyeBrightnessSmooth_f() {return 1.0;}
 #endif
 
 vec3 FogCol() {
@@ -25,8 +25,8 @@ float OldFog(float isEyeInWater) {
     float fog_s = max(gl_Fog.scale, 0.005 * FOG_MULT_F);
 
     //Calculate fog intensity in or out of water.
-    float fog = (isEyeInWater > 0.0) ? 1.-exp(-gl_FogFragCoord * fog_d):
-    clamp((gl_FogFragCoord-gl_Fog.start) * fog_s, 0., 1.);
+    float fog = (isEyeInWater > 0.0) ? 1.0-exp(-gl_FogFragCoord * fog_d):
+    clamp((gl_FogFragCoord-gl_Fog.start) * fog_s, 0.0, 1.0);
 
     return fog;
 }
@@ -36,8 +36,8 @@ float OldFogS(float isEyeInWater, float scale) {
     float fog_s = max(gl_Fog.scale, 0.005 * scale);
 
     //Calculate fog intensity in or out of water.
-    float fog = (isEyeInWater > 0.0) ? 1.-exp(-gl_FogFragCoord * fog_d):
-    clamp((gl_FogFragCoord-gl_Fog.start) * fog_s, 0., 1.);
+    float fog = (isEyeInWater > 0.0) ? 1.0-exp(-gl_FogFragCoord * fog_d):
+    clamp((gl_FogFragCoord-gl_Fog.start) * fog_s, 0.0, 1.0);
 
     return fog;
 }
@@ -48,24 +48,24 @@ float FogNDF(float isEyeInWater, float fog_l) {
     #ifdef DISTANT_HORIZONS
         float f = far;
         float fog_s = (5 * FOG_MULT_F)/f;
-        float fog_start = f/2.;
+        float fog_start = f/2.0;
     #else
         float f = far;
-        float fog_start = gl_Fog.start/5. + 10. * FOG_MULT_F;
+        float fog_start = gl_Fog.start/5.0 + 10.0 * FOG_MULT_F;
     #endif
 
     float fog = 0.0;
     if (isEyeInWater > 0.0) {
-        fog = 1.-exp(-fog_l * fog_d);
+        fog = 1.0-exp(-fog_l * fog_d);
     }
     #if defined(DYNAMIC_FOG) && !defined(THE_NETHER) && !defined(THE_END)
-        if (f - fog_start <= 0.) return 1.-eyeBrightnessSmooth_f();
+        if (f - fog_start <= 0.0) return 1.0-eyeBrightnessSmooth_f();
     #else
-        if (f - fog_start <= 0.) return 0.;
+        if (f - fog_start <= 0.0) return 0.0;
     #endif
     else
     {
-        fog = clamp((fog_l - fog_start) / (f - fog_start) + fog_d*(1.-1./fog_l), 0., 1.);
+        fog = clamp((fog_l - fog_start) / (f - fog_start) + fog_d*(1.0-1.0/fog_l), 0.0, 1.0);
     }
 
     //if (fog >= 1) discard;
@@ -94,15 +94,15 @@ float Fog(float isEyeInWater, float time8_rf, float fog_l) {
         float fog_start = gl_Fog.start/5 + 10 * FOG_MULT_F;
     #endif
 
-    float fog = 0.;
+    float fog = 0.0;
 
-    if (isEyeInWater > 0.) {
-        fog = 1.-exp(-fog_l * fog_d);
+    if (isEyeInWater > 0.0) {
+        fog = 1.0-exp(-fog_l * fog_d);
     }
-    if (f - fog_start <= 0.) return 0.;
+    if (f - fog_start <= 0.0) return 0.0;
     else
     {
-        fog = clamp((fog_l - fog_start) / (f - fog_start) + fog_d*(1.-1./fog_l), 0., 1.);
+        fog = clamp((fog_l - fog_start) / (f - fog_start) + fog_d*(1.0-1.0/fog_l), 0.0, 1.0);
     }
 
     #ifdef DITTER_FOG
@@ -124,7 +124,7 @@ void DhDitterFog(float time8_rf, float linearDepth){
     #ifdef DISTANT_HORIZONS
         #ifdef DITTER_FOG
             #ifdef DH
-                if (time8_rf >= (linearDepth - (far - dhNearPlane))/(far*0.1) + 2.) {
+                if (time8_rf >= (linearDepth - (far - dhNearPlane))/(far*0.1) + 2.0) {
                     discard;
                 }
             #else

--- a/shaders/program/composite.fsh
+++ b/shaders/program/composite.fsh
@@ -18,7 +18,7 @@ varying vec2 texcoord_vs;
 	{
 		ivec2 ip = ivec2(mod(p * vec2(viewWidth, viewHeight) / RENDER_PIXEL_SIZE, 2.0));
 
-		// 2x2 Bayer matrix values (0.0.3), normalized to 0.0.1
+		// 2x2 Bayer matrix values (0..3), normalized to 0..1
 		int index = ip.x + ip.y * 2;
 		float bayer[4] = float[4](
 			0.0 / 4.0,
@@ -35,8 +35,8 @@ varying vec2 texcoord_vs;
 		// Convert screen coordinates to 4x4 grid
 		ivec2 ip = ivec2(mod(p * vec2(viewWidth, viewHeight) / RENDER_PIXEL_SIZE, 4.0));
 
-		// 4x4 Bayer matrix (normalized 0.0.1)
-		// This is the classic ordered dithering pattern, slightly remapped to 0.0.1
+		// 4x4 Bayer matrix (normalized 0..1)
+		// This is the classic ordered dithering pattern, slightly remapped to 0..1
 		float bayer[16] = float[16](
 			0.0 / 16.0,  8.0 / 16.0,  2.0 / 16.0, 10.0 / 16.0,
 		12.0 / 16.0,  4.0 / 16.0, 14.0 / 16.0,  6.0 / 16.0,

--- a/shaders/program/composite.fsh
+++ b/shaders/program/composite.fsh
@@ -18,7 +18,7 @@ varying vec2 texcoord_vs;
 	{
 		ivec2 ip = ivec2(mod(p * vec2(viewWidth, viewHeight) / RENDER_PIXEL_SIZE, 2.0));
 
-		// 2x2 Bayer matrix values (0..3), normalized to 0..1
+		// 2x2 Bayer matrix values (0.0.3), normalized to 0.0.1
 		int index = ip.x + ip.y * 2;
 		float bayer[4] = float[4](
 			0.0 / 4.0,
@@ -35,8 +35,8 @@ varying vec2 texcoord_vs;
 		// Convert screen coordinates to 4x4 grid
 		ivec2 ip = ivec2(mod(p * vec2(viewWidth, viewHeight) / RENDER_PIXEL_SIZE, 4.0));
 
-		// 4x4 Bayer matrix (normalized 0..1)
-		// This is the classic ordered dithering pattern, slightly remapped to 0..1
+		// 4x4 Bayer matrix (normalized 0.0.1)
+		// This is the classic ordered dithering pattern, slightly remapped to 0.0.1
 		float bayer[16] = float[16](
 			0.0 / 16.0,  8.0 / 16.0,  2.0 / 16.0, 10.0 / 16.0,
 		12.0 / 16.0,  4.0 / 16.0, 14.0 / 16.0,  6.0 / 16.0,
@@ -209,7 +209,7 @@ void main() {
 	sum = vec3(
 #if BLUR_SIZE != -1
 		(left1[0] + left2[0] + center[0])/3,
-		center[1] * (1. - (BLOOM_SIZE_F / 4.)),
+		center[1] * (1.0 - (BLOOM_SIZE_F / 4.0)),
 		(right1[2] + right2[2] + center[2])/3);
 #else
 		center[0],

--- a/shaders/program/gbuffers_basic.fsh
+++ b/shaders/program/gbuffers_basic.fsh
@@ -37,7 +37,7 @@ void main()
     }
 
     // Apply blindness
-    col.rgb *= (1.-blindness);
+    col.rgb *= (1.0-blindness);
     //Output the result.
     gl_FragData[0] = col;
 }

--- a/shaders/program/gbuffers_clouds.fsh
+++ b/shaders/program/gbuffers_clouds.fsh
@@ -21,7 +21,7 @@ void main()
     #endif
 
     //Visibility amount.
-    vec3 light = vec3(1.-blindness);
+    vec3 light = vec3(1.0-blindness);
     //Sample texture times Visibility.
     vec4 col = color * vec4(light,1) * texture2D(texture,coord0);
 

--- a/shaders/program/gbuffers_skytextured.fsh
+++ b/shaders/program/gbuffers_skytextured.fsh
@@ -14,7 +14,7 @@ varying vec2 coord0;
 void main()
 {
     //Visibility amount.
-    vec3 light = vec3(1.-blindness);
+    vec3 light = vec3(1.0-blindness);
     //Sample texture times Visibility.
     vec4 col = vec4(light,1) * texture2D(texture,coord0);
 

--- a/shaders/program/gbuffers_textured.fsh
+++ b/shaders/program/gbuffers_textured.fsh
@@ -93,7 +93,7 @@ vec3 CalculateLightStrengthAndColor(float x)
         vec3 monLight = coord1.y * MOONLIGHT_STRENGHT_F * vec3(COLOR_LIGHT_SKY_NIGHT_R_F, COLOR_LIGHT_SKY_NIGHT_G_F, COLOR_LIGHT_SKY_NIGHT_B_F);
         sunLight = max(sunLight, monLight * (1-sunLightStrength));
 #endif
-    vec3 skyLight = max(sunLight, sunsetLight) * (1. - rainStrength / 2.);
+    vec3 skyLight = max(sunLight, sunsetLight) * (1.0 - rainStrength / 2.0);
 
     vec3 blockLight = coord1.x * vec3(COLOR_LIGHT_BLOCK_R_F, COLOR_LIGHT_BLOCK_G_F, COLOR_LIGHT_BLOCK_B_F);
 
@@ -138,11 +138,11 @@ void main()
 
 #if LIGHTMAP_DITERING != -1
     if (renderStage == MC_RENDER_STAGE_TERRAIN_SOLID) {
-        light = (1. - blindness) * max(light + (LIGHTMAP_DITERING_F * time8_rf / 16.0), 0.0);
+        light = (1.0 - blindness) * max(light + (LIGHTMAP_DITERING_F * time8_rf / 16.0), 0.0);
     } else
 #endif
     {
-        light *= 1. - blindness;
+        light *= 1.0 - blindness;
     }
 
     // Apply darkness and lighting strength.

--- a/shaders/program/gbuffers_textured.vsh
+++ b/shaders/program/gbuffers_textured.vsh
@@ -52,7 +52,7 @@ void main()
     //Calculate view space normal.
     vec3 normal = gl_NormalMatrix * gl_Normal;
     //Use flat for flat "blocks" or world space normal for solid blocks.
-    normal = (mcEntity.x==1.) ? vec3(0,1,0) : (gbufferModelViewInverse * vec4(normal,0)).xyz;
+    normal = (mcEntity.x==1.0) ? vec3(0,1,0) : (gbufferModelViewInverse * vec4(normal,0)).xyz;
 
     //Calculate simple lighting. Thanks to @PepperCode1
     float light = min(normal.x * normal.x * 0.6f + normal.y * normal.y * 0.25f * (3.0f + normal.y) + normal.z * normal.z * 0.8f, 1.0f);


### PR DESCRIPTION
Fixed non-canonical float literals and implicit int-to-float returns in fog shaders ('common/fog.fsh').

Several float-returning fog functions used implicit integer literals in return statements ('0', '1') and shorthand float literals such as '240.'. While accepted by many GLSL compilers, stricter drivers and older GLSL implementations may reject or warn on these constructs.

Replaced implicit integer return literals with explicit float equivalents ('0.0', '1.0') and normalised shorthand float literals ('240' --> '240.0') for improved GLSL compatibility and parser strictness compliance.
